### PR TITLE
Fix unit tests with Rails 4.2 and 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
-  - 2.0.0
-  - 1.9.3
+  - 2.3.3
 notifications:
   email:
     recipients:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+
+## 0.3.2 (2017-03-06)
+* add `responders` gem as dependency to support `respond_to` method
+* fix unit tests with Rails 4.2 and Rails 5.0
+
 ## 0.3.1 (2014-08-07)
 * add `eager_load` option to load callbacks into classes in non-eager-loaded enviroments
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem "rake"
 gem 'tzinfo'
 gem 'mocha'
 gem 'pry'
+gem 'responders', '~> 2.0' # to support Rails 4.2

--- a/lib/stripe/callbacks/builder.rb
+++ b/lib/stripe/callbacks/builder.rb
@@ -42,8 +42,9 @@ module Stripe
             when Array, Set
               stringified_keys = only.map(&:to_s)
               proc do |target, evt|
-                intersection =  evt.data.previous_attributes.keys - stringified_keys
-                block.call(target, evt) if intersection != evt.data.previous_attributes.keys
+                stringified_previous_attributes_keys = evt.data.previous_attributes.keys.map(&:to_s)
+                intersection =  stringified_previous_attributes_keys - stringified_keys
+                block.call(target, evt) if intersection != stringified_previous_attributes_keys
               end
             when nil
               block

--- a/lib/stripe/rails/version.rb
+++ b/lib/stripe/rails/version.rb
@@ -1,5 +1,5 @@
 module Stripe
   module Rails
-    VERSION = '0.3.1'
+    VERSION = '0.3.2'
   end
 end

--- a/stripe-rails.gemspec
+++ b/stripe-rails.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |gem|
   gem.version       = Stripe::Rails::VERSION
   gem.add_dependency 'rails', '>= 3'
   gem.add_dependency 'stripe'
+  gem.add_dependency 'responders', '~> 2.0'
 end

--- a/stripe-rails.gemspec
+++ b/stripe-rails.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Stripe::Rails::VERSION
   gem.add_dependency 'rails', '>= 3'
-  gem.add_dependency 'stripe'
+  gem.add_dependency 'stripe', '< 2'
   gem.add_dependency 'responders', '~> 2.0'
 end

--- a/test/callbacks_spec.rb
+++ b/test/callbacks_spec.rb
@@ -156,7 +156,7 @@ describe Stripe::Callbacks do
     describe 'specified as a lambda' do
       before do
         @observer.class_eval do
-          after_invoice_updated :only => proc {|target, evt| evt.data.previous_attributes.has_key? "closed"} do |i,e|
+          after_invoice_updated :only => proc {|target, evt| evt.data.previous_attributes.to_hash.has_key? :closed} do |i,e|
             events << e
           end
         end

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -14,7 +14,7 @@ Dummy::Application.configure do
 
   # Configure static asset server for tests with Cache-Control for performance
   config.serve_static_assets = true
-  config.static_cache_control = "public, max-age=3600"
+  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -14,7 +14,6 @@ Dummy::Application.configure do
 
   # Configure static asset server for tests with Cache-Control for performance
   config.serve_static_assets = true
-  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true


### PR DESCRIPTION
I realized unit tests were broken on a fresh install using Ruby v2.3 with Rails 4.2 and Rails 5.0.
This PR:

- adds support for Rails 4.2 (thanks to the `responders` gem)
- fixes unit tests
- removes the deprecated configuration `config.static_cache_control`
- fix `stripe` dependency below the v2.0 (starting from this version, they dropped the support of Ruby 1.9)

